### PR TITLE
Guard ProductsChanged invocation in ProductService

### DIFF
--- a/BlazorEcommerce/Client/Services/ProductService/ProductService.cs
+++ b/BlazorEcommerce/Client/Services/ProductService/ProductService.cs
@@ -62,7 +62,7 @@
             if (Products.Count == 0)
                 Message = "No products found";
 
-            ProductsChanged.Invoke();
+            ProductsChanged?.Invoke();
         }
 
         public async Task<List<string>> GetProductSearchSuggestions(string searchText)


### PR DESCRIPTION
## Summary
- make the ProductsChanged event invocation null-safe to avoid null reference exceptions when no handlers are registered

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68deb60a004c8323a23e61fb36ada433